### PR TITLE
Add Qwen Compatibility to ZSMerge  ature/qwen compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ python -m unittest tests.test_mistral_att
 python -m unittest tests.test_llama_att
 python -m unittest tests.test_llama3_att
 python -m unittest tests.test_falcon_att
+python -m unittest tests.test_qwen2_att
 ```
 
 ### Validate throughput

--- a/exam/exam_throughput.py
+++ b/exam/exam_throughput.py
@@ -8,6 +8,10 @@ import argparse
 import time
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
 from mergekv import AttentionForward as AF
+from dotenv import load_dotenv
+# env
+load_dotenv()
+ACCESS_TOKEN=os.getenv("ACCESS_TOKEN")
 
 
 
@@ -73,13 +77,14 @@ def load_model(model_name, torch_dtype=torch.float16):
     """
     # Load model components
     config = AutoConfig.from_pretrained(model_name)
-    tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True, token=ACCESS_TOKEN)
     tokenizer.pad_token = tokenizer.eos_token  # Set pad token to avoid warnings
     
     # Load model with automatic device placement
     model = AutoModelForCausalLM.from_pretrained(
         model_name,
-        torch_dtype=torch_dtype
+        torch_dtype=torch_dtype,
+        token=ACCESS_TOKEN
     ).to("cuda")  # Explicit GPU placement for benchmarking
     
     return config, tokenizer, model

--- a/mergekv/mergekv.py
+++ b/mergekv/mergekv.py
@@ -8,6 +8,7 @@ import transformers
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
 from transformers.cache_utils import Cache, DynamicCache, StaticCache
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding, LlamaAttention, apply_rotary_pos_emb
+from transformers.models.qwen2.modeling_qwen2 import Qwen2SdpaAttention
 # from transformers.models.llama.modeling_llama import repeat_kv
 from dotenv import load_dotenv
 
@@ -25,7 +26,8 @@ global g_llama_sdpa_attn_forward_orgn, g_mistral_sdpa_attn_forward_orgn, g_falco
 g_llama_sdpa_attn_forward_orgn = transformers.models.llama.modeling_llama.LlamaSdpaAttention.forward
 g_mistral_sdpa_attn_forward_orgn = transformers.models.mistral.modeling_mistral.MistralSdpaAttention.forward
 g_falcon_sdpa_attn_forward_orgn = transformers.models.falcon.modeling_falcon.FalconAttention.forward
-
+global g_qwen_sdpa_attn_forward_orgn
+g_qwen_sdpa_attn_forward_orgn = Qwen2SdpaAttention.forward
 
 
 def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
@@ -610,11 +612,14 @@ class AttentionForward:
             transformers.models.llama.modeling_llama.LlamaSdpaAttention.forward = args_dec(llama_sdpa_attn_forward_, **kws)
             transformers.models.mistral.modeling_mistral.MistralSdpaAttention.forward = args_dec(llama_sdpa_attn_forward_, **kws)
             transformers.models.falcon.modeling_falcon.FalconAttention.forward = args_dec(llama_sdpa_attn_forward_, **kws)
+            Qwen2SdpaAttention.forward = args_dec(llama_sdpa_attn_forward_, **kws)
         else:
             global g_llama_sdpa_attn_forward_orgn, g_mistral_sdpa_attn_forward_orgn, g_falcon_sdpa_attn_forward_orgn
             transformers.models.llama.modeling_llama.LlamaSdpaAttention.forward = g_llama_sdpa_attn_forward_orgn
             transformers.models.mistral.modeling_mistral.MistralSdpaAttention.forward = g_mistral_sdpa_attn_forward_orgn
             transformers.models.falcon.modeling_falcon.FalconAttention.forward = g_falcon_sdpa_attn_forward_orgn
+            Qwen2SdpaAttention.forward = g_qwen_sdpa_attn_forward_orgn
+
 
 
 

--- a/scripts/e_rouge.sh
+++ b/scripts/e_rouge.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # meta-llama/Llama-2-13b-hf
-model_path='meta-llama/Llama-2-7b-hf'
+model_path='Qwen/Qwen1.5-7B'
 device='cuda'
 shots=3
 budget=0.05

--- a/scripts/e_throughput.sh
+++ b/scripts/e_throughput.sh
@@ -4,15 +4,15 @@
   
   
 python exam/exam_throughput.py \
-  --model_name meta-llama/Llama-2-13b-hf \
+  --model_name Qwen/Qwen1.5-7B \
   --batch_size 16 \
-  --prompt_length 2048 \
-  --generate_length 2048
+  --prompt_length 512 \
+  --generate_length 512
   
 python exam/exam_throughput.py \
-  --model_name meta-llama/Llama-2-13b-hf \
+  --model_name Qwen/Qwen1.5-7B \
   --batch_size 16 \
-  --prompt_length 2048 \
-  --generate_length 2048 \
+  --prompt_length 512 \
+  --generate_length 512 \
   --cache_ratio 0.05 \
   --merge

--- a/tests/test_qwen2_att.py
+++ b/tests/test_qwen2_att.py
@@ -1,0 +1,18 @@
+import unittest
+from .test_utils import cls_init, gen_equal, cleanup_after_test
+
+@cleanup_after_test
+class TestQwen2Generator(unittest.TestCase):
+    model_name="Qwen/Qwen1.5-7B"
+    
+    @classmethod
+    def setUpClass(cls):
+        cls_init(cls)
+        return super().setUpClass()
+
+    def test_gen(self):
+        gen_equal(self)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Implemented monkey patch for Qwen2SdpaAttention
- Changed the default model in the files of e-rouge and e-throughput to "Qwen/Qwen1.5-7B"
- - Verified throughput and ROUGE evaluation
